### PR TITLE
Remove warning in ruby-2.7.2

### DIFF
--- a/lib/tarantool16/schema.rb
+++ b/lib/tarantool16/schema.rb
@@ -189,12 +189,12 @@ module Tarantool16
 
     def map_ops(ops)
       ops.map do |op|
-        case _1 = op[1]
+        case op1 = op[1]
         when Integer
           op
         when Symbol, String
           _op = op.dup
-          _op[1] = @field_names[_1].pos
+          _op[1] = @field_names[op1].pos
           _op
         when Array
           fld_pos = case op[0]
@@ -205,7 +205,7 @@ module Tarantool16
                 else
                   raise "No field #{op[0].inspect} in #{name_sid}"
                 end
-          _1.dup.insert(1, fld_pos)
+          op1.dup.insert(1, fld_pos)
         end
       end
     end


### PR DESCRIPTION
Ruby 2.7.2 warning:

Gems/usr/local/bundle/gems/tarantool16-0.1.1/lib/tarantool16/schema.rb:192: warning: `_1' is reserved for numbered parameter; consider another name